### PR TITLE
Add basic news section with dynamic articles

### DIFF
--- a/app/news/[slug]/page.js
+++ b/app/news/[slug]/page.js
@@ -1,0 +1,31 @@
+import fs from 'fs';
+import path from 'path';
+import { notFound } from 'next/navigation';
+
+export default function NewsArticle({ params }) {
+  const { slug } = params;
+  const filePath = path.join(process.cwd(), 'content', 'news', `${slug}.json`);
+  if (!fs.existsSync(filePath)) {
+    notFound();
+  }
+
+  const { title, date, content } = JSON.parse(
+    fs.readFileSync(filePath, 'utf8')
+  );
+
+  return (
+    <article className="prose">
+      <h1>{title}</h1>
+      <p className="text-sm text-gray-500">{date}</p>
+      <p>{content}</p>
+    </article>
+  );
+}
+
+export function generateStaticParams() {
+  const newsDir = path.join(process.cwd(), 'content', 'news');
+  return fs
+    .readdirSync(newsDir)
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => ({ slug: file.replace(/\.json$/, '') }));
+}

--- a/app/news/page.js
+++ b/app/news/page.js
@@ -1,0 +1,40 @@
+import fs from 'fs';
+import path from 'path';
+import Link from 'next/link';
+
+export default function NewsPage() {
+  const newsDir = path.join(process.cwd(), 'content', 'news');
+  const files = fs.readdirSync(newsDir);
+  const articles = files
+    .filter((file) => file.endsWith('.json'))
+    .map((file) => {
+      const { title, date } = JSON.parse(
+        fs.readFileSync(path.join(newsDir, file), 'utf8')
+      );
+      return {
+        slug: file.replace(/\.json$/, ''),
+        title,
+        date,
+      };
+    })
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Actualités</h1>
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <li key={article.slug}>
+            <Link
+              href={`/news/${article.slug}`}
+              className="text-blue-500 hover:underline"
+            >
+              {article.title}
+            </Link>
+            <span className="block text-sm text-gray-500">{article.date}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/content/news/patch-notes.json
+++ b/content/news/patch-notes.json
@@ -1,0 +1,5 @@
+{
+  "title": "Notes de patch 1.0",
+  "date": "2025-02-15",
+  "content": "Cette mise à jour apporte des améliorations majeures et corrige plusieurs bugs signalés par la communauté."
+}

--- a/content/news/welcome.json
+++ b/content/news/welcome.json
@@ -1,0 +1,5 @@
+{
+  "title": "Bienvenue sur Mortal Online France",
+  "date": "2025-01-01",
+  "content": "Nous lançons notre nouveau site pour la communauté francophone de Mortal Online 2. Restez à l'écoute pour des guides et des nouvelles!"
+}


### PR DESCRIPTION
## Summary
- add JSON news articles under `content/news`
- list news articles in `/news`
- render individual articles via dynamic route `/news/[slug]`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (warning about Next.js ESLint plugin)
- `npm run build`
- `npm start &` + `curl -s http://localhost:3000/news | grep -o '<h1[^>]*>[^<]*</h1>'`
- `curl -s http://localhost:3000/news/welcome | grep -o '<h1[^>]*>[^<]*</h1>'`
- `curl -s http://localhost:3000/news/patch-notes | grep -o '<h1[^>]*>[^<]*</h1>'`


------
https://chatgpt.com/codex/tasks/task_e_689f4e22773c832cb9faeb1484be4128