### PR TITLE
feat: add dynamic guide page loader

### DIFF
--- a/app/guides/[slug]/page.js
+++ b/app/guides/[slug]/page.js
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+import { notFound } from 'next/navigation';
+
+export default async function GuidePage({ params }) {
+  const { slug } = params;
+  const filePath = path.join(process.cwd(), 'content', 'guides', `${slug}.mdx`);
+
+  if (!fs.existsSync(filePath)) {
+    notFound();
+  }
+
+  const GuideContent = (await import(`../../../content/guides/${slug}.mdx`)).default;
+
+  return (
+    <article className="prose">
+      <GuideContent />
+    </article>
+  );
+}
+
+export function generateStaticParams() {
+  const guidesDir = path.join(process.cwd(), 'content', 'guides');
+  if (!fs.existsSync(guidesDir)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(guidesDir)
+    .filter((file) => file.endsWith('.mdx'))
+    .map((file) => ({ slug: file.replace(/\.mdx$/, '') }));
+}


### PR DESCRIPTION
## Summary
- implement dynamic guide page loading from MDX files
- handle missing guide files with 404 and pre-generate static params

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: How would you like to configure ESLint?)

------
https://chatgpt.com/codex/tasks/task_e_689f52002e14832cbbb05e4357a84eca