### PR TITLE
fix: resolve next-auth module path

### DIFF
--- a/app/admin/page.js
+++ b/app/admin/page.js
@@ -1,4 +1,4 @@
-import { getServerSession } from "next-auth";
+import { getServerSession } from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 
 /* eslint-disable @next/next/no-html-link-for-pages */

--- a/app/api/auth/[...nextauth]/route.js
+++ b/app/api/auth/[...nextauth]/route.js
@@ -1,4 +1,4 @@
-import NextAuthPkg from "next-auth";
+import NextAuthPkg from "next-auth/next";
 import { authOptions } from "@/lib/auth";
 
 const NextAuth = NextAuthPkg.default ?? NextAuthPkg;


### PR DESCRIPTION
## Summary
- adjust NextAuth imports to use explicit `next-auth/next` entry
- ensure server session uses `next-auth/next` for compatibility

## Testing
- `npm test`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_689f6bf89334832c9347555d5ad064c4