### PR TITLE
Add guilds page and monochrome theme

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,25 +1,25 @@
 @import "tailwindcss";
 
 @theme inline {
-  --font-sans: var(--font-geist-sans);
-  --font-mono: var(--font-geist-mono);
+  --font-sans: var(--font-vollkorn), sans-serif;
 }
 
 @layer base {
   :root {
-    --background: #ffffff;
-    --foreground: #171717;
-  }
-  @media (prefers-color-scheme: dark) {
-    :root {
-      --background: #0a0a0a;
-      --foreground: #ededed;
-    }
+    --background: #000000;
+    --foreground: #ffffff;
   }
   body {
     color: var(--foreground);
     background: var(--background);
     font-family: var(--font-sans);
+  }
+  a {
+    color: var(--foreground);
+    text-decoration: underline;
+  }
+  a:hover {
+    color: #cccccc;
   }
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 
 @theme inline {
-  --font-sans: var(--font-vollkorn), sans-serif;
+  --font-sans: "Vollkorn SC", sans-serif;
 }
 
 @layer base {

--- a/app/guilds/page.js
+++ b/app/guilds/page.js
@@ -1,0 +1,48 @@
+import Image from "next/image";
+
+export const metadata = {
+  title: "Guildes",
+  description: "Présentation des guildes et médias",
+};
+
+export default function GuildsPage() {
+  return (
+    <div className="space-y-8">
+      <h1 className="text-3xl font-bold">Présentation des guildes</h1>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Stream Twitch</h2>
+        <div className="aspect-video w-full">
+          <iframe
+            src="https://player.twitch.tv/?channel=example&parent=localhost"
+            allowFullScreen
+            className="w-full h-full"
+          ></iframe>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Vidéo YouTube</h2>
+        <div className="aspect-video w-full">
+          <iframe
+            src="https://www.youtube.com/embed/dQw4w9WgXcQ"
+            title="YouTube video player"
+            allowFullScreen
+            className="w-full h-full"
+          ></iframe>
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-2xl font-semibold">Capture d&apos;écran</h2>
+        <Image
+          src="/mo2-hero.jpg"
+          alt="Capture du jeu"
+          width={800}
+          height={450}
+          className="w-full h-auto"
+        />
+      </section>
+    </div>
+  );
+}

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,12 +1,7 @@
-import { Vollkorn_SC } from "next/font/google";
+/* eslint-disable @next/next/no-page-custom-font */
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
-
-const vollkorn = Vollkorn_SC({
-  variable: "--font-vollkorn",
-  subsets: ["latin"],
-});
 
 export const metadata = {
   title: "Mortal Online France",
@@ -16,9 +11,19 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="fr">
-      <body
-        className={`${vollkorn.variable} antialiased min-h-screen flex flex-col`}
-      >
+      <head>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        <link
+          href="https://fonts.googleapis.com/css2?family=Vollkorn+SC:wght@400;600;700;900&display=swap"
+          rel="stylesheet"
+        />
+      </head>
+      <body className="antialiased min-h-screen flex flex-col">
         <Header />
         <main className="flex-1 container mx-auto p-4">{children}</main>
         <Footer />

--- a/app/layout.js
+++ b/app/layout.js
@@ -1,15 +1,10 @@
-import { Geist, Geist_Mono } from "next/font/google";
+import { Vollkorn_SC } from "next/font/google";
 import "./globals.css";
 import Header from "@/components/Header";
 import Footer from "@/components/Footer";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
+const vollkorn = Vollkorn_SC({
+  variable: "--font-vollkorn",
   subsets: ["latin"],
 });
 
@@ -22,7 +17,7 @@ export default function RootLayout({ children }) {
   return (
     <html lang="fr">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased min-h-screen flex flex-col`}
+        className={`${vollkorn.variable} antialiased min-h-screen flex flex-col`}
       >
         <Header />
         <main className="flex-1 container mx-auto p-4">{children}</main>

--- a/components/Footer.js
+++ b/components/Footer.js
@@ -1,6 +1,6 @@
 export default function Footer() {
   return (
-    <footer className="bg-gray-100 text-center py-4 text-sm">
+    <footer className="bg-black text-white text-center py-4 text-sm">
       © {new Date().getFullYear()} Mortal Online France – site non officiel
     </footer>
   );

--- a/components/Header.js
+++ b/components/Header.js
@@ -2,11 +2,12 @@ import Link from 'next/link';
 
 export default function Header() {
   return (
-    <header className="bg-gray-900 text-white">
+    <header className="bg-black text-white">
       <nav className="container mx-auto flex gap-4 p-4">
         <Link href="/">Accueil</Link>
         <Link href="/news">Actualités</Link>
         <Link href="/guides">Guides</Link>
+        <Link href="/guilds">Guildes</Link>
         <Link href="/contact">Contact</Link>
       </nav>
     </header>


### PR DESCRIPTION
## Summary
- switch site styling to black and white with Vollkorn SC font
- add header/footer styling and new Guilds page with Twitch/YouTube embeds
- update navigation to include Guildes section

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689f789efb74832cafa2d70dd63b9269