### PR TITLE
feat: show flags on language switcher

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import Image from "next/image";
 import { usePathname } from "next/navigation";
 
 const labels = {
@@ -38,8 +39,14 @@ export default function Header({ lang }) {
         <Link href={`/${lang}/contact`}>{t.contact}</Link>
         <Link
           href={switchHref}
-          className="ml-auto border px-2 py-1 rounded"
+          className="ml-auto border px-2 py-1 rounded flex items-center gap-2"
         >
+          <Image
+            src={`/flags/${lang}.svg`}
+            width={20}
+            height={15}
+            alt={lang === "fr" ? "Français" : "English"}
+          />
           {switchLabel}
         </Link>
       </nav>

--- a/public/flags/en.svg
+++ b/public/flags/en.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="3" height="2" fill="#fff"/>
+  <rect width="3" height="0.5" y="0.75" fill="#CE1124"/>
+  <rect width="0.5" height="2" x="1.25" fill="#CE1124"/>
+</svg>

--- a/public/flags/fr.svg
+++ b/public/flags/fr.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 3 2">
+  <rect width="1" height="2" fill="#0055A4"/>
+  <rect width="1" height="2" x="1" fill="#fff"/>
+  <rect width="1" height="2" x="2" fill="#EF4135"/>
+</svg>


### PR DESCRIPTION
## Summary
- show current language's flag beside the switch button
- add SVG assets for French and English flags

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c6bc9c44832c85e69404e76b8054