### PR TITLE
Fix language switch flag and alt text

### DIFF
--- a/components/Header.js
+++ b/components/Header.js
@@ -42,10 +42,10 @@ export default function Header({ lang }) {
           className="ml-auto border px-2 py-1 rounded flex items-center gap-2"
         >
           <Image
-            src={`/flags/${lang}.svg`}
+            src={`/flags/${otherLang}.svg`}
             width={20}
             height={15}
-            alt={lang === "fr" ? "Français" : "English"}
+            alt={switchLabel}
           />
           {switchLabel}
         </Link>


### PR DESCRIPTION
## Summary
- show target language flag in header toggle
- use target language text for alt attribute

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a5d06f0a38832cbbe1489001a81716