### PR TITLE
Derive header language from path

### DIFF
--- a/app/layout.js
+++ b/app/layout.js
@@ -26,7 +26,7 @@ export default function RootLayout({ children, params }) {
         />
       </head>
       <body className="antialiased min-h-screen flex flex-col">
-        <Header lang={lang} />
+        <Header />
         <main className="flex-1 container mx-auto p-4">{children}</main>
         <Footer lang={lang} />
       </body>

--- a/components/Header.js
+++ b/components/Header.js
@@ -21,9 +21,10 @@ const labels = {
   },
 };
 
-export default function Header({ lang }) {
-  const t = labels[lang] || labels.fr;
+export default function Header() {
   const pathname = usePathname();
+  const lang = pathname.startsWith("/en") ? "en" : "fr";
+  const t = labels[lang] || labels.fr;
   const otherLang = lang === "fr" ? "en" : "fr";
 
   // Remove the current language prefix from the path. If the resulting


### PR DESCRIPTION
## Summary
- compute active language inside `Header` using `usePathname`
- drop now-unneeded `lang` prop from `Header` and layout
- keep layout language handling via route params

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5d612f9e8832c94d0194529ce8617