### PR TITLE
feat: add superadmin admin pages

### DIFF
--- a/app/[lang]/admin/comments/actions.js
+++ b/app/[lang]/admin/comments/actions.js
@@ -1,0 +1,17 @@
+"use server";
+import fs from "fs";
+import path from "path";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+
+export async function deleteComment(formData) {
+  const session = await getServerSession(authOptions);
+  if (session?.user.role !== "superadmin") {
+    throw new Error("Forbidden");
+  }
+  const id = parseInt(formData.get("id"), 10);
+  const filePath = path.join(process.cwd(), "data", "comments.json");
+  const comments = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const newComments = comments.filter((c) => c.id !== id);
+  fs.writeFileSync(filePath, JSON.stringify(newComments, null, 2));
+}

--- a/app/[lang]/admin/comments/page.js
+++ b/app/[lang]/admin/comments/page.js
@@ -1,0 +1,46 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import comments from "@/data/comments.json";
+import { deleteComment } from "./actions";
+
+const texts = {
+  fr: {
+    title: "Gestion des commentaires",
+    delete: "Supprimer",
+    accessDenied: "Accès refusé",
+  },
+  en: {
+    title: "Comment moderation",
+    delete: "Delete",
+    accessDenied: "Access denied",
+  },
+};
+
+export default async function CommentsAdminPage({ params }) {
+  const lang = params.lang;
+  const t = texts[lang] || texts.fr;
+  const session = await getServerSession(authOptions);
+
+  if (!session || session.user.role !== "superadmin") {
+    return <p className="p-8">{t.accessDenied}</p>;
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl mb-4">{t.title}</h1>
+      <ul>
+        {comments.map((c) => (
+          <li key={c.id} className="mb-2">
+            {c.text}
+            <form action={deleteComment} className="inline-block ml-2">
+              <input type="hidden" name="id" value={c.id} />
+              <button type="submit" className="underline">
+                {t.delete}
+              </button>
+            </form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/[lang]/admin/guilds/actions.js
+++ b/app/[lang]/admin/guilds/actions.js
@@ -1,0 +1,17 @@
+"use server";
+import fs from "fs";
+import path from "path";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+
+export async function deleteGuild(formData) {
+  const session = await getServerSession(authOptions);
+  if (session?.user.role !== "superadmin") {
+    throw new Error("Forbidden");
+  }
+  const id = parseInt(formData.get("id"), 10);
+  const filePath = path.join(process.cwd(), "data", "guilds.json");
+  const guilds = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const newGuilds = guilds.filter((g) => g.id !== id);
+  fs.writeFileSync(filePath, JSON.stringify(newGuilds, null, 2));
+}

--- a/app/[lang]/admin/guilds/page.js
+++ b/app/[lang]/admin/guilds/page.js
@@ -1,0 +1,46 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import guilds from "@/data/guilds.json";
+import { deleteGuild } from "./actions";
+
+const texts = {
+  fr: {
+    title: "Gestion des guildes",
+    delete: "Supprimer",
+    accessDenied: "Accès refusé",
+  },
+  en: {
+    title: "Guild management",
+    delete: "Delete",
+    accessDenied: "Access denied",
+  },
+};
+
+export default async function GuildsAdminPage({ params }) {
+  const lang = params.lang;
+  const t = texts[lang] || texts.fr;
+  const session = await getServerSession(authOptions);
+
+  if (!session || session.user.role !== "superadmin") {
+    return <p className="p-8">{t.accessDenied}</p>;
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl mb-4">{t.title}</h1>
+      <ul>
+        {guilds.map((g) => (
+          <li key={g.id} className="mb-2">
+            {g.name}
+            <form action={deleteGuild} className="inline-block ml-2">
+              <input type="hidden" name="id" value={g.id} />
+              <button type="submit" className="underline">
+                {t.delete}
+              </button>
+            </form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/[lang]/admin/page.js
+++ b/app/[lang]/admin/page.js
@@ -11,6 +11,9 @@ const texts = {
     welcome: "Bienvenue",
     role: "Rôle",
     signOut: "Se déconnecter",
+    guilds: "Guildes",
+    comments: "Commentaires",
+    users: "Utilisateurs",
   },
   en: {
     signIn: "Sign in with Discord",
@@ -19,6 +22,9 @@ const texts = {
     welcome: "Welcome",
     role: "Role",
     signOut: "Sign out",
+    guilds: "Guilds",
+    comments: "Comments",
+    users: "Users",
   },
 };
 
@@ -37,7 +43,7 @@ export default async function AdminPage({ params }) {
     );
   }
 
-  if (session.user.role !== "admin") {
+  if (session.user.role !== "superadmin") {
     return <p className="p-8">{t.accessDenied}</p>;
   }
 
@@ -50,6 +56,23 @@ export default async function AdminPage({ params }) {
       <p className="mb-4">
         {t.role}: {session.user.role}
       </p>
+      <nav className="mb-4 space-y-2">
+        <div>
+          <a href={`/${lang}/admin/guilds`} className="underline">
+            {t.guilds}
+          </a>
+        </div>
+        <div>
+          <a href={`/${lang}/admin/comments`} className="underline">
+            {t.comments}
+          </a>
+        </div>
+        <div>
+          <a href={`/${lang}/admin/users`} className="underline">
+            {t.users}
+          </a>
+        </div>
+      </nav>
       <a href="/api/auth/signout" className="underline">
         {t.signOut}
       </a>

--- a/app/[lang]/admin/users/actions.js
+++ b/app/[lang]/admin/users/actions.js
@@ -1,0 +1,21 @@
+"use server";
+import fs from "fs";
+import path from "path";
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+
+export async function updateUserRole(formData) {
+  const session = await getServerSession(authOptions);
+  if (session?.user.role !== "superadmin") {
+    throw new Error("Forbidden");
+  }
+  const id = formData.get("id");
+  const role = formData.get("role");
+  const filePath = path.join(process.cwd(), "data", "users.json");
+  const users = JSON.parse(fs.readFileSync(filePath, "utf8"));
+  const user = users.find((u) => u.id === id);
+  if (user) {
+    user.role = role;
+    fs.writeFileSync(filePath, JSON.stringify(users, null, 2));
+  }
+}

--- a/app/[lang]/admin/users/page.js
+++ b/app/[lang]/admin/users/page.js
@@ -1,0 +1,50 @@
+import { getServerSession } from "next-auth/next";
+import { authOptions } from "@/lib/auth";
+import users from "@/data/users.json";
+import { updateUserRole } from "./actions";
+
+const texts = {
+  fr: {
+    title: "Gestion des utilisateurs",
+    update: "Mettre à jour",
+    accessDenied: "Accès refusé",
+  },
+  en: {
+    title: "User management",
+    update: "Update",
+    accessDenied: "Access denied",
+  },
+};
+
+export default async function UsersAdminPage({ params }) {
+  const lang = params.lang;
+  const t = texts[lang] || texts.fr;
+  const session = await getServerSession(authOptions);
+
+  if (!session || session.user.role !== "superadmin") {
+    return <p className="p-8">{t.accessDenied}</p>;
+  }
+
+  return (
+    <div className="p-8">
+      <h1 className="text-xl mb-4">{t.title}</h1>
+      <ul>
+        {users.map((u) => (
+          <li key={u.id} className="mb-2">
+            {u.name} - {u.role}
+            <form action={updateUserRole} className="inline-block ml-2">
+              <input type="hidden" name="id" value={u.id} />
+              <select name="role" defaultValue={u.role} className="border p-1">
+                <option value="user">user</option>
+                <option value="admin">admin</option>
+              </select>
+              <button type="submit" className="ml-1 underline">
+                {t.update}
+              </button>
+            </form>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/data/comments.json
+++ b/data/comments.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "text": "Great guild!" },
+  { "id": 2, "text": "Needs improvement." }
+]

--- a/data/guilds.json
+++ b/data/guilds.json
@@ -1,0 +1,4 @@
+[
+  { "id": 1, "name": "Knights of Valor" },
+  { "id": 2, "name": "Shadow Clan" }
+]

--- a/data/users.json
+++ b/data/users.json
@@ -1,0 +1,5 @@
+[
+  { "id": "1", "name": "Alice", "role": "user" },
+  { "id": "2", "name": "Bob", "role": "admin" },
+  { "id": "3", "name": "Charlie", "role": "user" }
+]

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,8 +2,11 @@
 import DiscordProviderImport from "next-auth/providers/discord";
 
 export function getUserRole(id) {
-  const admins = process.env.ADMIN_IDS?.split(",") || [];
-  return admins.includes(id) ? "admin" : "user";
+  const superAdmins = process.env.SUPERADMIN_IDS?.split(",") || [];
+  const guildAdmins = process.env.ADMIN_IDS?.split(",") || [];
+  if (superAdmins.includes(id)) return "superadmin";
+  if (guildAdmins.includes(id)) return "admin";
+  return "user";
 }
 
 const DiscordProvider = DiscordProviderImport.default ?? DiscordProviderImport;

--- a/lib/auth.test.js
+++ b/lib/auth.test.js
@@ -1,16 +1,21 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getUserRole } from './auth.js';
 
-describe('getUserRole', () => {
-  beforeEach(() => {
-    process.env.ADMIN_IDS = '1,2';
-  });
+  describe('getUserRole', () => {
+    beforeEach(() => {
+      process.env.ADMIN_IDS = '1,2';
+      process.env.SUPERADMIN_IDS = '99';
+    });
 
-  it('returns admin when id is in ADMIN_IDS', () => {
-    expect(getUserRole('1')).toBe('admin');
-  });
+    it('returns admin when id is in ADMIN_IDS', () => {
+      expect(getUserRole('1')).toBe('admin');
+    });
 
-  it('returns user when id is not in ADMIN_IDS', () => {
-    expect(getUserRole('3')).toBe('user');
+    it('returns user when id is not in ADMIN_IDS', () => {
+      expect(getUserRole('3')).toBe('user');
+    });
+
+    it('returns superadmin when id is in SUPERADMIN_IDS', () => {
+      expect(getUserRole('99')).toBe('superadmin');
+    });
   });
-});


### PR DESCRIPTION
## Summary
- add superadmin role handling in auth
- expose admin dashboard with links to guild, comment and user management
- implement superadmin-only pages to manage guilds, comments, and user roles

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa207b9bdc832c9978af95e28a76cc