### PR TITLE
Add guild detail page with voting and comments

### DIFF
--- a/app/[lang]/guilds/[slug]/GuildInteractions.js
+++ b/app/[lang]/guilds/[slug]/GuildInteractions.js
@@ -1,0 +1,87 @@
+"use client";
+
+import { useState } from "react";
+
+export default function GuildInteractions({ guildId, initialAverage, initialComments }) {
+  const [average, setAverage] = useState(initialAverage);
+  const [comments, setComments] = useState(initialComments);
+  const [page, setPage] = useState(1);
+
+  async function submitVote(rating) {
+    const res = await fetch(`/api/guilds/${guildId}/vote`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ rating }),
+    });
+    const data = await res.json();
+    setAverage(data.average);
+  }
+
+  async function submitComment(e) {
+    e.preventDefault();
+    const form = e.target;
+    const content = form.content.value.trim();
+    if (!content) return;
+    const optimistic = { id: Math.random().toString(36).slice(2), content };
+    setComments([optimistic, ...comments]);
+    form.reset();
+    const res = await fetch(`/api/guilds/${guildId}/comments`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content }),
+    });
+    const saved = await res.json();
+    setComments((prev) => [saved, ...prev.filter((c) => c.id !== optimistic.id)]);
+  }
+
+  async function loadMore() {
+    const nextPage = page + 1;
+    const res = await fetch(`/api/guilds/${guildId}/comments?page=${nextPage}`);
+    const data = await res.json();
+    setComments((prev) => [...prev, ...data.comments]);
+    setPage(nextPage);
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <p className="font-semibold">Average rating: {average.toFixed(1)}</p>
+        <div className="flex gap-2 mt-2">
+          {[1, 2, 3, 4, 5].map((n) => (
+            <button
+              key={n}
+              className="border px-2 py-1"
+              onClick={() => submitVote(n)}
+            >
+              {n}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      <div>
+        <form onSubmit={submitComment} className="flex gap-2 mb-4">
+          <input
+            type="text"
+            name="content"
+            className="border flex-1 p-1"
+            placeholder="Add a comment"
+          />
+          <button type="submit" className="border px-2 py-1">
+            Send
+          </button>
+        </form>
+        <ul className="space-y-2">
+          {comments.map((c) => (
+            <li key={c.id} className="border p-2">
+              {c.content}
+            </li>
+          ))}
+        </ul>
+        <button onClick={loadMore} className="mt-4 border px-2 py-1">
+          Load more
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/app/[lang]/guilds/[slug]/page.js
+++ b/app/[lang]/guilds/[slug]/page.js
@@ -1,0 +1,36 @@
+import { notFound } from "next/navigation";
+import { guilds, getGuildBySlug, getAverageRating, getComments } from "../../../../lib/guilds.js";
+import GuildInteractions from "./GuildInteractions.js";
+
+export default function GuildPage({ params }) {
+  const { slug } = params;
+  const guild = getGuildBySlug(slug);
+  if (!guild) {
+    notFound();
+  }
+  const average = getAverageRating(guild);
+  const initial = getComments(guild.id, 1, 10);
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">{guild.name}</h1>
+      <p>{guild.description}</p>
+      <GuildInteractions
+        guildId={guild.id}
+        initialAverage={average}
+        initialComments={initial.comments}
+      />
+    </div>
+  );
+}
+
+export function generateStaticParams() {
+  const langs = ["fr", "en"]; // generate for both languages
+  const params = [];
+  for (const lang of langs) {
+    for (const g of guilds) {
+      params.push({ lang, slug: g.slug });
+    }
+  }
+  return params;
+}

--- a/app/[lang]/guilds/page.js
+++ b/app/[lang]/guilds/page.js
@@ -1,4 +1,6 @@
 import Image from "next/image";
+import Link from "next/link";
+import { guilds } from "../../../lib/guilds.js";
 
 export async function generateMetadata({ params: { lang } }) {
   return {
@@ -34,6 +36,14 @@ export default function GuildsPage({ params }) {
   return (
     <div className="space-y-8">
       <h1 className="text-3xl font-bold">{t.title}</h1>
+
+      <ul className="list-disc ml-6 space-y-2">
+        {guilds.map((g) => (
+          <li key={g.id}>
+            <Link href={`/${lang}/guilds/${g.slug}`}>{g.name}</Link>
+          </li>
+        ))}
+      </ul>
 
       <section className="space-y-4">
         <h2 className="text-2xl font-semibold">{t.twitch}</h2>

--- a/app/api/guilds/[id]/comments/route.js
+++ b/app/api/guilds/[id]/comments/route.js
@@ -1,0 +1,27 @@
+import { addComment, getComments } from "../../../../lib/guilds.js";
+import { authOptions } from "../../../../lib/auth.js";
+import { getServerSession } from "next-auth";
+
+export async function GET(request, { params }) {
+  const { searchParams } = new URL(request.url);
+  const page = Number(searchParams.get("page") || 1);
+  const limit = Number(searchParams.get("limit") || 10);
+  const data = getComments(params.id, page, limit);
+  if (!data) {
+    return new Response("Guild not found", { status: 404 });
+  }
+  return Response.json(data);
+}
+
+export async function POST(request, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const { content } = await request.json();
+  const comment = addComment(params.id, session.user.id, content);
+  if (!comment) {
+    return new Response("Guild not found", { status: 404 });
+  }
+  return Response.json(comment, { status: 201 });
+}

--- a/app/api/guilds/[id]/vote/route.js
+++ b/app/api/guilds/[id]/vote/route.js
@@ -1,0 +1,28 @@
+import { addVote, getGuildById, getAverageRating } from "../../../../lib/guilds.js";
+import { authOptions } from "../../../../lib/auth.js";
+import { getServerSession } from "next-auth";
+
+export async function POST(request, { params }) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    return new Response("Unauthorized", { status: 401 });
+  }
+  const { rating } = await request.json();
+  const guild = addVote(params.id, session.user.id, Number(rating));
+  if (!guild) {
+    return new Response("Guild not found", { status: 404 });
+  }
+  const average = getAverageRating(guild);
+  return Response.json({ average });
+}
+
+export async function GET(request, { params }) {
+  const session = await getServerSession(authOptions);
+  const guild = getGuildById(params.id);
+  if (!guild) {
+    return new Response("Guild not found", { status: 404 });
+  }
+  const average = getAverageRating(guild);
+  const userRating = session ? guild.votes[session.user.id] : undefined;
+  return Response.json({ average, userRating });
+}

--- a/lib/guilds.js
+++ b/lib/guilds.js
@@ -1,0 +1,62 @@
+import { randomUUID } from "crypto";
+
+export const guilds = [
+  {
+    id: "1",
+    slug: "mof",
+    name: "Mortal Online France",
+    description: "Community guild for French players.",
+    votes: {}, // userId -> rating
+    comments: [],
+  },
+  {
+    id: "2",
+    slug: "knights",
+    name: "Knights of Nave",
+    description: "Honorable defenders of Nave.",
+    votes: {},
+    comments: [],
+  },
+];
+
+export function getGuildBySlug(slug) {
+  return guilds.find((g) => g.slug === slug);
+}
+
+export function getGuildById(id) {
+  return guilds.find((g) => g.id === id);
+}
+
+export function addVote(guildId, userId, rating) {
+  const guild = getGuildById(guildId);
+  if (!guild) return null;
+  guild.votes[userId] = rating;
+  return guild;
+}
+
+export function getAverageRating(guild) {
+  const values = Object.values(guild.votes);
+  if (values.length === 0) return 0;
+  return values.reduce((a, b) => a + b, 0) / values.length;
+}
+
+export function addComment(guildId, userId, content) {
+  const guild = getGuildById(guildId);
+  if (!guild) return null;
+  const comment = {
+    id: randomUUID(),
+    userId,
+    content,
+    createdAt: Date.now(),
+  };
+  guild.comments.unshift(comment);
+  return comment;
+}
+
+export function getComments(guildId, page = 1, limit = 10) {
+  const guild = getGuildById(guildId);
+  if (!guild) return null;
+  const start = (page - 1) * limit;
+  const comments = guild.comments.slice(start, start + limit);
+  return { comments, total: guild.comments.length };
+}


### PR DESCRIPTION
## Summary
- add in-memory guild data with votes and comments
- implement guild voting and comment APIs
- build guild detail page with live rating and discussion

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa1f2ecc58832caf637a624bffb393