### PR TITLE
Refactor user role helper and add tests

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -2,19 +2,7 @@
 import DiscordProviderImport from "next-auth/providers/discord";
 import { PrismaAdapter } from "@next-auth/prisma-adapter";
 import { prisma } from "./prisma.js";
-
-export function getUserRole(id) {
-  const superAdmins = process.env.SUPERADMIN_IDS?.split(",") || [];
-  const admins = process.env.ADMIN_IDS?.split(",") || [];
-  if (superAdmins.includes(id)) return "superadmin";
-  return admins.includes(id) ? "admin" : "user";
-  return admins.includes(id) ? "superadmin" : "user";
-  const superAdmins = process.env.SUPERADMIN_IDS?.split(",") || [];
-  const guildAdmins = process.env.ADMIN_IDS?.split(",") || [];
-  if (superAdmins.includes(id)) return "superadmin";
-  if (guildAdmins.includes(id)) return "admin";
-  return "user";
-}
+import { getUserRole } from "./roles.js";
 
 const DiscordProvider = DiscordProviderImport.default ?? DiscordProviderImport;
 

--- a/lib/auth.test.js
+++ b/lib/auth.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { getUserRole } from './auth.js';
+import { getUserRole } from './roles.js';
 
 describe('getUserRole', () => {
   beforeEach(() => {
@@ -10,26 +10,13 @@ describe('getUserRole', () => {
   it('returns superadmin when id is in SUPERADMIN_IDS', () => {
     expect(getUserRole('3')).toBe('superadmin');
   });
-  describe('getUserRole', () => {
-    beforeEach(() => {
-      process.env.ADMIN_IDS = '1,2';
-      process.env.SUPERADMIN_IDS = '99';
-    });
 
-  it('returns superadmin when id is in ADMIN_IDS', () => {
-    expect(getUserRole('1')).toBe('superadmin');
+  it('returns admin when id is in ADMIN_IDS', () => {
+    expect(getUserRole('1')).toBe('admin');
   });
-    it('returns admin when id is in ADMIN_IDS', () => {
-      expect(getUserRole('1')).toBe('admin');
-    });
-
-    it('returns user when id is not in ADMIN_IDS', () => {
-      expect(getUserRole('3')).toBe('user');
-    });
 
   it('returns user when id is not in ADMIN_IDS or SUPERADMIN_IDS', () => {
     expect(getUserRole('4')).toBe('user');
-    it('returns superadmin when id is in SUPERADMIN_IDS', () => {
-      expect(getUserRole('99')).toBe('superadmin');
-    });
   });
+});
+

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -1,0 +1,8 @@
+export function getUserRole(id) {
+  const superAdmins = process.env.SUPERADMIN_IDS?.split(',') || [];
+  const admins = process.env.ADMIN_IDS?.split(',') || [];
+  if (superAdmins.includes(id)) return 'superadmin';
+  if (admins.includes(id)) return 'admin';
+  return 'user';
+}
+


### PR DESCRIPTION
## Summary
- extract `getUserRole` helper into dedicated module
- simplify auth options to use new helper
- add unit tests for role resolution

## Testing
- `npm test`
- `npm run lint` (fails: Parsing error: Identifier 'guilds' has already been declared)


------
https://chatgpt.com/codex/tasks/task_e_68aa272a7ba4832cb368c5274dc5f42a