### PR TITLE
Refactor guild API to use guildId slug

### DIFF
--- a/app/api/guilds/[guildId]/comments/route.js
+++ b/app/api/guilds/[guildId]/comments/route.js
@@ -1,12 +1,12 @@
-import { addComment, getComments } from "../../../../lib/guilds.js";
-import { authOptions } from "../../../../lib/auth.js";
+import { addComment, getComments } from "@/lib/guilds";
+import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 
 export async function GET(request, { params }) {
   const { searchParams } = new URL(request.url);
   const page = Number(searchParams.get("page") || 1);
   const limit = Number(searchParams.get("limit") || 10);
-  const data = getComments(params.id, page, limit);
+  const data = getComments(params.guildId, page, limit);
   if (!data) {
     return new Response("Guild not found", { status: 404 });
   }
@@ -19,7 +19,7 @@ export async function POST(request, { params }) {
     return new Response("Unauthorized", { status: 401 });
   }
   const { content } = await request.json();
-  const comment = addComment(params.id, session.user.id, content);
+  const comment = addComment(params.guildId, session.user.id, content);
   if (!comment) {
     return new Response("Guild not found", { status: 404 });
   }

--- a/app/api/guilds/[guildId]/status/route.js
+++ b/app/api/guilds/[guildId]/status/route.js
@@ -9,20 +9,20 @@ export async function POST(request, { params }) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
   }
 
-  const { id } = params;
+  const { guildId } = params;
   const { action } = await request.json();
-  const guild = getGuildById(id);
+  const guild = getGuildById(guildId);
 
   if (!guild) {
     return NextResponse.json({ error: 'Guild not found' }, { status: 404 });
   }
 
   if (action === 'approve') {
-    updateGuildStatus(id, 'published');
-    addGuildAdmin(id, guild.authorId);
+    updateGuildStatus(guildId, 'published');
+    addGuildAdmin(guildId, guild.authorId);
     notifyUser(guild.authorId, 'Your guild has been approved');
   } else if (action === 'reject') {
-    updateGuildStatus(id, 'rejected');
+    updateGuildStatus(guildId, 'rejected');
     notifyUser(guild.authorId, 'Your guild has been rejected');
   } else {
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });

--- a/app/api/guilds/[guildId]/vote/route.js
+++ b/app/api/guilds/[guildId]/vote/route.js
@@ -1,5 +1,5 @@
-import { addVote, getGuildById, getAverageRating } from "../../../../lib/guilds.js";
-import { authOptions } from "../../../../lib/auth.js";
+import { addVote, getGuildById, getAverageRating } from "@/lib/guilds";
+import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 
 export async function POST(request, { params }) {
@@ -8,7 +8,7 @@ export async function POST(request, { params }) {
     return new Response("Unauthorized", { status: 401 });
   }
   const { rating } = await request.json();
-  const guild = addVote(params.id, session.user.id, Number(rating));
+  const guild = addVote(params.guildId, session.user.id, Number(rating));
   if (!guild) {
     return new Response("Guild not found", { status: 404 });
   }
@@ -18,7 +18,7 @@ export async function POST(request, { params }) {
 
 export async function GET(request, { params }) {
   const session = await getServerSession(authOptions);
-  const guild = getGuildById(params.id);
+  const guild = getGuildById(params.guildId);
   if (!guild) {
     return new Response("Guild not found", { status: 404 });
   }


### PR DESCRIPTION
## Summary
- consolidate guild API dynamic segments under `[guildId]`
- update comment, status, and vote handlers to use `params.guildId`
- fix imports to use root aliases

## Testing
- `npm run build` *(fails: Module parse failures and JSON parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2d2d7d74832ca7ba564415ae0ca8