### PR TITLE
Consolidate guild API routes

### DIFF
--- a/app/api/guilds/[guildId]/comments/route.js
+++ b/app/api/guilds/[guildId]/comments/route.js
@@ -1,12 +1,12 @@
-import { addComment, getComments } from "../../../../lib/guilds.js";
-import { authOptions } from "../../../../lib/auth.js";
+import { addComment, getComments } from "@/lib/guilds";
+import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 
 export async function GET(request, { params }) {
   const { searchParams } = new URL(request.url);
   const page = Number(searchParams.get("page") || 1);
   const limit = Number(searchParams.get("limit") || 10);
-  const data = getComments(params.id, page, limit);
+  const data = getComments(params.guildId, page, limit);
   if (!data) {
     return new Response("Guild not found", { status: 404 });
   }
@@ -19,7 +19,7 @@ export async function POST(request, { params }) {
     return new Response("Unauthorized", { status: 401 });
   }
   const { content } = await request.json();
-  const comment = addComment(params.id, session.user.id, content);
+  const comment = addComment(params.guildId, session.user.id, content);
   if (!comment) {
     return new Response("Guild not found", { status: 404 });
   }

--- a/app/api/guilds/[guildId]/status/route.js
+++ b/app/api/guilds/[guildId]/status/route.js
@@ -9,20 +9,20 @@ export async function POST(request, { params }) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
   }
 
-  const { id } = params;
+  const { guildId } = params;
   const { action } = await request.json();
-  const guild = getGuildById(id);
+  const guild = getGuildById(guildId);
 
   if (!guild) {
     return NextResponse.json({ error: 'Guild not found' }, { status: 404 });
   }
 
   if (action === 'approve') {
-    updateGuildStatus(id, 'published');
-    addGuildAdmin(id, guild.authorId);
+    updateGuildStatus(guildId, 'published');
+    addGuildAdmin(guildId, guild.authorId);
     notifyUser(guild.authorId, 'Your guild has been approved');
   } else if (action === 'reject') {
-    updateGuildStatus(id, 'rejected');
+    updateGuildStatus(guildId, 'rejected');
     notifyUser(guild.authorId, 'Your guild has been rejected');
   } else {
     return NextResponse.json({ error: 'Invalid action' }, { status: 400 });

--- a/app/api/guilds/[guildId]/vote/route.js
+++ b/app/api/guilds/[guildId]/vote/route.js
@@ -1,5 +1,5 @@
-import { addVote, getGuildById, getAverageRating } from "../../../../lib/guilds.js";
-import { authOptions } from "../../../../lib/auth.js";
+import { addVote, getGuildById, getAverageRating } from "@/lib/guilds";
+import { authOptions } from "@/lib/auth";
 import { getServerSession } from "next-auth";
 
 export async function POST(request, { params }) {
@@ -8,7 +8,7 @@ export async function POST(request, { params }) {
     return new Response("Unauthorized", { status: 401 });
   }
   const { rating } = await request.json();
-  const guild = addVote(params.id, session.user.id, Number(rating));
+  const guild = addVote(params.guildId, session.user.id, Number(rating));
   if (!guild) {
     return new Response("Guild not found", { status: 404 });
   }
@@ -18,7 +18,7 @@ export async function POST(request, { params }) {
 
 export async function GET(request, { params }) {
   const session = await getServerSession(authOptions);
-  const guild = getGuildById(params.id);
+  const guild = getGuildById(params.guildId);
   if (!guild) {
     return new Response("Guild not found", { status: 404 });
   }

--- a/data/guilds.json
+++ b/data/guilds.json
@@ -1,4 +1,3 @@
-[]
 [
   { "id": 1, "name": "Knights of Valor" },
   { "id": 2, "name": "Shadow Clan" }

--- a/lib/guilds.js
+++ b/lib/guilds.js
@@ -1,15 +1,35 @@
-// Simple in-memory guild store and helpers
+import { randomUUID } from "crypto";
 
-// Each guild has: id, description, banner, videos [{url, type}], admins [userIds]
-const guilds = [
+export const guilds = [
   {
     id: "1",
-    description: "",
+    slug: "mof",
+    name: "Mortal Online France",
+    description: "Community guild for French players.",
     banner: "",
     videos: [],
     admins: [],
+    status: "pending",
+    authorId: "1",
+    votes: {},
+    comments: [],
+  },
+  {
+    id: "2",
+    slug: "knights",
+    name: "Knights of Nave",
+    description: "Honorable defenders of Nave.",
+    banner: "",
+    videos: [],
+    admins: [],
+    status: "pending",
+    authorId: "2",
+    votes: {},
+    comments: [],
   },
 ];
+
+const userNotifications = new Map();
 
 export function getGuild(id) {
   return guilds.find((g) => g.id === id);
@@ -32,43 +52,12 @@ export function isGuildAdmin(id, userId) {
   return guild.admins.includes(userId);
 }
 
-export function addGuildAdmin(id, userId) {
-  const guild = getGuild(id);
+export function addGuildAdmin(guildId, userId) {
+  const guild = getGuild(guildId);
   if (!guild) return false;
   if (!guild.admins.includes(userId)) guild.admins.push(userId);
   return true;
 }
-
-export { guilds };
-const guilds = [
-  { id: '1', name: 'Example Guild', status: 'pending', authorId: '1' },
-];
-
-const guildAdmins = new Map();
-const userNotifications = new Map();
-
-export function getPendingGuilds() {
-  return guilds.filter((g) => g.status === 'pending');
-import { randomUUID } from "crypto";
-
-export const guilds = [
-  {
-    id: "1",
-    slug: "mof",
-    name: "Mortal Online France",
-    description: "Community guild for French players.",
-    votes: {}, // userId -> rating
-    comments: [],
-  },
-  {
-    id: "2",
-    slug: "knights",
-    name: "Knights of Nave",
-    description: "Honorable defenders of Nave.",
-    votes: {},
-    comments: [],
-  },
-];
 
 export function getGuildBySlug(slug) {
   return guilds.find((g) => g.slug === slug);
@@ -84,11 +73,6 @@ export function updateGuildStatus(id, status) {
   return guild;
 }
 
-export function addGuildAdmin(guildId, userId) {
-  if (!guildAdmins.has(guildId)) guildAdmins.set(guildId, new Set());
-  guildAdmins.get(guildId).add(userId);
-}
-
 export function notifyUser(userId, message) {
   if (!userNotifications.has(userId)) userNotifications.set(userId, []);
   userNotifications.get(userId).push(message);
@@ -96,6 +80,11 @@ export function notifyUser(userId, message) {
 
 export function getUserNotifications(userId) {
   return userNotifications.get(userId) ?? [];
+}
+
+export function getPendingGuilds() {
+  return guilds.filter((g) => g.status === "pending");
+}
 
 export function addVote(guildId, userId, rating) {
   const guild = getGuildById(guildId);
@@ -130,3 +119,4 @@ export function getComments(guildId, page = 1, limit = 10) {
   const comments = guild.comments.slice(start, start + limit);
   return { comments, total: guild.comments.length };
 }
+

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,16 +1,11 @@
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = globalThis.prisma || new PrismaClient();
+const globalForPrisma = globalThis;
 
+export const prisma = globalForPrisma.prisma || new PrismaClient();
 if (process.env.NODE_ENV !== "production") {
-  globalThis.prisma = prisma;
+  globalForPrisma.prisma = prisma;
 }
-import { PrismaClient } from '@prisma/client'
 
-const globalForPrisma = globalThis
+export default prisma;
 
-const prisma = globalForPrisma.prisma || new PrismaClient()
-
-if (process.env.NODE_ENV !== 'production') globalForPrisma.prisma = prisma
-
-export default prisma


### PR DESCRIPTION
## Summary
- use a single `[guildId]` slug for all guild API routes
- reorganize guild helper module and Prisma client setup
- fix malformed guilds seed data

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Failed to collect page data for /api/auth/[...nextauth] due to Prisma schema validation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68aa2c5636f4832c982b66908cfd13ae