### PR TITLE
Add default superadmin

### DIFF
--- a/lib/auth.test.js
+++ b/lib/auth.test.js
@@ -11,6 +11,11 @@ describe('getUserRole', () => {
     expect(getUserRole('3')).toBe('superadmin');
   });
 
+  it('returns superadmin for default superadmin id when env is empty', () => {
+    process.env.SUPERADMIN_IDS = '';
+    expect(getUserRole('112288484521172992')).toBe('superadmin');
+  });
+
   it('returns admin when id is in ADMIN_IDS', () => {
     expect(getUserRole('1')).toBe('admin');
   });

--- a/lib/roles.js
+++ b/lib/roles.js
@@ -1,7 +1,12 @@
+const DEFAULT_SUPERADMINS = ['112288484521172992'];
+
 export function getUserRole(id) {
-  const superAdmins = process.env.SUPERADMIN_IDS?.split(',') || [];
-  const admins = process.env.ADMIN_IDS?.split(',') || [];
-  if (superAdmins.includes(id)) return 'superadmin';
+  const superAdmins = new Set([
+    ...(process.env.SUPERADMIN_IDS?.split(',').filter(Boolean) ?? []),
+    ...DEFAULT_SUPERADMINS,
+  ]);
+  const admins = process.env.ADMIN_IDS?.split(',').filter(Boolean) ?? [];
+  if (superAdmins.has(id)) return 'superadmin';
   if (admins.includes(id)) return 'admin';
   return 'user';
 }


### PR DESCRIPTION
## Summary
- ensure Discord ID 112288484521172992 is always treated as a superadmin
- cover default superadmin behavior with new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68aa4112389c832c8eda75076f73ef57