### PR TITLE
Add sign-in callback to assign username from email

### DIFF
--- a/lib/auth.js
+++ b/lib/auth.js
@@ -6,6 +6,13 @@ import { getUserRole } from "./roles.js";
 
 const DiscordProvider = DiscordProviderImport.default ?? DiscordProviderImport;
 
+function slug(str) {
+  return str
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/(^-|-$)/g, "");
+}
+
 export const authOptions = {
   adapter: PrismaAdapter(prisma),
   providers: [
@@ -15,6 +22,13 @@ export const authOptions = {
     }),
   ],
   callbacks: {
+    async signIn({ user }) {
+      if (!user.name && user.email) {
+        const localPart = user.email.slice(0, user.email.indexOf("@"));
+        user.name = slug(localPart);
+      }
+      return true;
+    },
     async jwt({ token, account, user }) {
       if (account && user) {
         const role = getUserRole(account.providerAccountId);

--- a/lib/auth.test.js
+++ b/lib/auth.test.js
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { getUserRole } from './roles.js';
+import { authOptions } from './auth.js';
 
 describe('getUserRole', () => {
   beforeEach(() => {
@@ -22,6 +23,15 @@ describe('getUserRole', () => {
 
   it('returns user when id is not in ADMIN_IDS or SUPERADMIN_IDS', () => {
     expect(getUserRole('4')).toBe('user');
+  });
+});
+
+describe('authOptions signIn', () => {
+  it('adds a slugified name based on email', async () => {
+    const user = { email: 'Test.User@example.com' };
+    const result = await authOptions.callbacks.signIn({ user });
+    expect(result).toBe(true);
+    expect(user.name).toBe('test-user');
   });
 });
 


### PR DESCRIPTION
## Summary
- slugify email local-part to generate a username during sign-in
- test sign-in callback sets slugified name

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa608805a8832c8dea91c64835fe7a