### PR TITLE
Enable NextAuth debug and custom error page

### DIFF
--- a/app/api/auth/error/page.js
+++ b/app/api/auth/error/page.js
@@ -1,0 +1,17 @@
+'use client';
+
+import { useSearchParams } from 'next/navigation';
+
+export default function AuthErrorPage() {
+  const searchParams = useSearchParams();
+  const error = searchParams.get('error');
+  const message = searchParams.get('message');
+
+  return (
+    <div>
+      <h1>Authentication Error</h1>
+      {error && <p>{error}</p>}
+      {message && <p>{message}</p>}
+    </div>
+  );
+}

--- a/lib/auth.js
+++ b/lib/auth.js
@@ -14,6 +14,10 @@ function slug(str) {
 }
 
 export const authOptions = {
+  debug: process.env.NODE_ENV !== "production",
+  pages: {
+    error: "/api/auth/error",
+  },
   adapter: PrismaAdapter(prisma),
   providers: [
     DiscordProvider({


### PR DESCRIPTION
## Summary
- enable NextAuth debug mode outside production
- add custom error page to display NextAuth `error` and `message`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa653d4f08832ca8b65374de860e85