### PR TITLE
fix: remove client search params usage

### DIFF
--- a/app/api/auth/error/page.js
+++ b/app/api/auth/error/page.js
@@ -1,11 +1,6 @@
-'use client';
-
-import { useSearchParams } from 'next/navigation';
-
-export default function AuthErrorPage() {
-  const searchParams = useSearchParams();
-  const error = searchParams.get('error');
-  const message = searchParams.get('message');
+export default function AuthErrorPage({ searchParams }) {
+  const error = searchParams?.error;
+  const message = searchParams?.message;
 
   return (
     <div>


### PR DESCRIPTION
## Summary
- handle auth error page search params on server to avoid suspense requirement

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa67602e5c832c9089b0e086ad0af7