### PR TITLE
Direct Discord sign-in link for admin access

### DIFF
--- a/app/[lang]/admin/guilds/new/page.js
+++ b/app/[lang]/admin/guilds/new/page.js
@@ -29,7 +29,7 @@ export default async function NewGuildPage({ params }) {
   if (!session) {
     return (
       <div className="p-8">
-        <a href="/api/auth/signin" className="underline">
+        <a href="/api/auth/signin/discord" className="underline">
           {t.signIn}
         </a>
       </div>

--- a/app/[lang]/admin/guilds/pending/page.js
+++ b/app/[lang]/admin/guilds/pending/page.js
@@ -28,7 +28,7 @@ export default async function PendingGuildsPage({ params }) {
   if (!session) {
     return (
       <div className="p-8">
-        <a href="/api/auth/signin" className="underline">
+        <a href="/api/auth/signin/discord" className="underline">
           {t.signIn}
         </a>
       </div>

--- a/app/[lang]/admin/page.js
+++ b/app/[lang]/admin/page.js
@@ -36,7 +36,7 @@ export default async function AdminPage({ params }) {
   if (!session) {
     return (
       <div className="p-8">
-        <a href="/api/auth/signin" className="underline">
+        <a href="/api/auth/signin/discord" className="underline">
           {t.signIn}
         </a>
       </div>


### PR DESCRIPTION
## Summary
- Link admin sign-in directly to the Discord provider to start OAuth immediately

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaedcec010832c921b3a72fcc6f749