### PR TITLE
fix: correct NEXTAUTH_URL and document prisma setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,6 +1,7 @@
 DISCORD_CLIENT_ID=1209314735959449681
 DISCORD_CLIENT_SECRET=FM2d4J6XqCrcY3bu6ti9ZI6vtuhefvH7
-NEXTAUTH_URL=https://mortal-online-france.vercel.app/api/auth/callback/discord
+# Base URL of your site (without trailing slash)
+NEXTAUTH_URL=https://mortal-online-france.vercel.app
 NEXTAUTH_SECRET=mortalonlinefrance
 ADMIN_IDS=112288484521172992
 SUPERADMIN_IDS=112288484521172992

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,7 @@
 DISCORD_CLIENT_ID=1209314735959449681
 DISCORD_CLIENT_SECRET=FM2d4J6XqCrcY3bu6ti9ZI6vtuhefvH7
-NEXTAUTH_URL=https://mortal-online-france.vercel.app/api/auth/callback/discord
+# Base URL of your site (without trailing slash)
+NEXTAUTH_URL=https://mortal-online-france.vercel.app
 NEXTAUTH_SECRET=mortalonlinefrance
 ADMIN_IDS=112288484521172992
 SUPERADMIN_IDS=112288484521172992

--- a/README.md
+++ b/README.md
@@ -39,6 +39,14 @@ Only users whose Discord IDs are listed in `ADMIN_IDS` receive the `admin` role.
 
 `NEXTAUTH_URL` must be set to the public URL of your site so that Discord OAuth can redirect users correctly.
 
+After configuring your environment variables, initialize the local database with:
+
+```
+npx prisma migrate dev
+```
+
+This applies the Prisma migrations and creates the necessary tables for authentication.
+
 ## Development
 
 Run the test suite and lint checks with:


### PR DESCRIPTION
## Summary
- correct NEXTAUTH_URL to use base site URL
- document running `prisma migrate` for auth tables

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aaf04b94a4832ca49531b11921fb5e