### PR TITLE
Handle SQLite path on Vercel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,10 @@ NEXTAUTH_URL=https://mortal-online-france.vercel.app
 NEXTAUTH_SECRET=mortalonlinefrance
 ADMIN_IDS=112288484521172992
 SUPERADMIN_IDS=112288484521172992
+# Local SQLite database for development
 DATABASE_URL="file:./dev.db"
+# On Vercel, override with a writable path like:
+# DATABASE_URL="file:/tmp/dev.db"
 NEXT_PUBLIC_FIREBASE_API_KEY=AIzaSyAZYvk65BLqVF4cQtUsYolJj2ZVse7wXzk
 NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN=mortalonlinefrance.firebaseapp.com
 NEXT_PUBLIC_FIREBASE_DATABASE_URL=https://mortalonlinefrance-default-rtdb.europe-west1.firebasedatabase.app

--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ npx prisma migrate dev
 
 This applies the Prisma migrations and creates the necessary tables for authentication.
 
+### Deploying with SQLite on Vercel
+
+Vercel's root filesystem is read-only. If you continue using SQLite, set the
+`DATABASE_URL` environment variable to a writable location such as
+`file:/tmp/dev.db`. The database will be ephemeral, so consider migrating to a
+managed database (PostgreSQL, MySQL, etc.) for persistent storage.
+
 ## Development
 
 Run the test suite and lint checks with:

--- a/lib/prisma.js
+++ b/lib/prisma.js
@@ -1,4 +1,14 @@
 import { PrismaClient } from "@prisma/client";
+
+// Default to a writable location when running on Vercel. Its root filesystem
+// is read‑only, so a SQLite database in the repository cannot be updated.
+// Fallback to `./dev.db` during local development.
+if (!process.env.DATABASE_URL) {
+  process.env.DATABASE_URL = process.env.VERCEL
+    ? "file:/tmp/dev.db"
+    : "file:./dev.db";
+}
+
 const globalForPrisma = global;
 export const prisma = globalForPrisma.prisma || new PrismaClient();
 if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;


### PR DESCRIPTION
## Summary
- document writable SQLite path on Vercel
- set Prisma to default to /tmp when DATABASE_URL is not provided

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1843c528832c9d72f91752b0bcea