### PR TITLE
feat: display Firestore articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,5 @@ import { addArticle, getArticles } from './lib/articles'
 await addArticle({ titre: 'Salut', contenu: 'Mon texte' })
 const articles = await getArticles()
 ```
+
+After adding some documents, visit `http://localhost:3000/fr/articles` to see them rendered from Firestore. Replace `fr` with `en` for the English version.

--- a/app/[lang]/articles/page.js
+++ b/app/[lang]/articles/page.js
@@ -1,0 +1,21 @@
+import { getArticles } from "@/lib/articles.js";
+
+export default async function ArticlesPage({ params }) {
+  const lang = params.lang;
+  const articles = await getArticles();
+  const heading = lang === "en" ? "Articles" : "Articles";
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">{heading}</h1>
+      <ul className="space-y-2">
+        {articles.map((article) => (
+          <li key={article.id} className="p-4 rounded-md bg-gray-900/60">
+            <h2 className="text-xl font-semibold text-white mb-1">{article.titre}</h2>
+            <p className="text-gray-300">{article.contenu}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add `/[lang]/articles` page showing Firestore content
- document Firestore page in README

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1bd60ec8832c9cabdb7986a68f4f