### PR TITLE
docs: guide enabling Firestore API

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,3 +101,7 @@ import { addArticle, getArticles } from './lib/articles'
 await addArticle({ titre: 'Salut', contenu: 'Mon texte' })
 const articles = await getArticles()
 ```
+
+After adding some documents, visit `http://localhost:3000/fr/articles` to see them rendered from Firestore. Replace `fr` with `en` for the English version.
+
+If you encounter a `PERMISSION_DENIED` error, ensure that the **Cloud Firestore API** is enabled for your Firebase project in the [Google Cloud Console](https://console.developers.google.com/apis/api/firestore.googleapis.com/overview).

--- a/app/[lang]/articles/page.js
+++ b/app/[lang]/articles/page.js
@@ -1,0 +1,34 @@
+import { getArticles } from "@/lib/articles";
+
+export default async function ArticlesPage({ params }) {
+  const lang = params.lang;
+  const heading = lang === "en" ? "Articles" : "Articles";
+
+  let articles = [];
+  let error = null;
+
+  try {
+    articles = await getArticles();
+  } catch (err) {
+    console.error(err);
+    error = lang === "en" ? "Failed to load articles." : "Échec du chargement des articles.";
+  }
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">{heading}</h1>
+      {error ? (
+        <p className="text-red-500">{error}</p>
+      ) : (
+        <ul className="space-y-2">
+          {articles.map((article) => (
+            <li key={article.id} className="p-4 rounded-md bg-gray-900/60">
+              <h2 className="text-xl font-semibold text-white mb-1">{article.titre}</h2>
+              <p className="text-gray-300">{article.contenu}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- handle Firestore errors on article page with a translated fallback message
- document enabling Cloud Firestore API when `PERMISSION_DENIED`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ab1bd60ec8832c9cabdb7986a68f4f